### PR TITLE
bump ember-electron version

### DIFF
--- a/cli/hearth.js
+++ b/cli/hearth.js
@@ -12,7 +12,7 @@ var Datastore = require('nedb'),
 let processes = {},
   resetTray,
   db = {
-    apps: Promise.promisifyAll(new Datastore({filename: path.resolve(__dirname, 'hearth.nedb.json'), autoload: true}))
+    apps: Promise.promisifyAll(new Datastore({filename: path.resolve(__dirname, '..', 'hearth.nedb.json'), autoload: true}))
   },
   binaries = {
     ember: path.join(__dirname, '..', 'node_modules', 'ember-cli', 'bin', 'ember'),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-electron": "0.3.4",
+    "ember-electron": "0.4.2",
     "ember-export-application-global": "^1.0.4",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "1.2.0"
@@ -43,6 +43,7 @@
   "main": "electron.js",
   "ember-electron": {
     "WHAT IS THIS?": "Please see the README.md",
+    "copy-files": ["electron.js", "package.json", "cli/*"],
     "name": null,
     "platform": null,
     "arch": null,


### PR DESCRIPTION
- adds `cli/` to copy-files (which allows hearth to be packaged again)
- changes db file path (which results in previously generated db file being ignored). The reason is to avoid accidental packaging a local database file, because `copy-files` includes the whole `cli/` dir.
