### PR TITLE
adds storing url on window close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ testem.log
 cli/hearth.nedb.json
 hearth.nedb.json
 electron-builds
+hearth_close_url
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -6,6 +6,7 @@ export default Ember.Controller.extend({
   ipc: inject.service(),
   electron: inject.service(),
 
+  ready: false,
   model: [],
 
   init(){
@@ -25,6 +26,8 @@ export default Ember.Controller.extend({
       this.get('store').peekAll('project')
         .filter(project => !projects[project.get('id')])
         .forEach(project => store.unloadRecord(project));
+      
+      this.set('ready', true);
     });
 
     this.get('ipc').on('cmd-start', (ev, cmd) => {

--- a/app/templates/project/detail/actions.hbs
+++ b/app/templates/project/detail/actions.hbs
@@ -1,7 +1,7 @@
 {{#unless help}}
     <div class="ui active inverted dimmer absolute-fill">
         <div class="ui text loader">
-            Reticulating splines <br>
+            Loading project ember commands <br>
         </div>
     </div>
 {{else}}

--- a/app/templates/project/loading.hbs
+++ b/app/templates/project/loading.hbs
@@ -1,0 +1,5 @@
+<div class="ui active inverted dimmer absolute-fill">
+    <div class="ui text loader">
+        Waiting for project to be loaded <br>
+    </div>
+</div>

--- a/cli/hearth.js
+++ b/cli/hearth.js
@@ -10,6 +10,8 @@ const path = require('path');
 const dialog = require('dialog');
 const term = require('./models/term').forPlatform();
 
+const HEARTH_URL_FILE = path.join(__dirname, '..', 'hearth_close_url');
+
 let processes = {},
   resetTray,
   db = {
@@ -80,6 +82,10 @@ function ready(app, window) {
   const Menu = electron.Menu;
   let tray = new Tray(path.join(__dirname, 'hearth-tray@2x.png'));
 
+  window.on('close', function onWillClose() {
+    fs.writeFileSync(HEARTH_URL_FILE, window.webContents.getURL(), 'utf8');
+  });
+
   resetTray = function () {
     let tpl = trayApps.map(app => {
       return {
@@ -100,6 +106,16 @@ function ready(app, window) {
   };
 
   resetTray();
+
+  fs.stat(HEARTH_URL_FILE, function (err, stats) {
+    if (!err) {
+      if (stats.isFile()) {
+        const lastUrl = fs.readFileSync(HEARTH_URL_FILE, 'utf8');
+        console.log('lasturl', lastUrl);
+        window.loadURL(lastUrl);
+      }
+    }
+  });
 }
 
 function emitProjects(ev) {

--- a/electron.js
+++ b/electron.js
@@ -3,7 +3,7 @@
 
 var electron = require('electron'),
   path = require('path'),
-  hearth  = require('./cli/hearth');
+  hearth = require('./cli/hearth');
 
 var app = electron.app;
 var ipc = electron.ipcMain;


### PR DESCRIPTION
adds detail model waiting for projects to be loaded (removes redirect to application)

Should fix https://github.com/EmberTown/ember-hearth/issues/112

The major change is that the project detail model hook now actively waits for the project list to be loaded. 
Currently it's implented via active polling. 
Next, we should probably add some sort of request api around the project list to avoid waiting for socket events.
